### PR TITLE
Fix ScriptableData ResetData not working

### DIFF
--- a/Assets/Unity Architecture 03 - Scriptable Object Pattern/Scripts/DNA/ScriptableBehaviour.cs
+++ b/Assets/Unity Architecture 03 - Scriptable Object Pattern/Scripts/DNA/ScriptableBehaviour.cs
@@ -17,6 +17,8 @@ namespace UnityArchitecture.ScriptableObjectPattern
 
         protected override void OnEnable()
         {
+            base.OnEnable();
+            
             EnablePlayerLoop();
 #if UNITY_EDITOR
             UnityEditor.EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
@@ -25,6 +27,7 @@ namespace UnityArchitecture.ScriptableObjectPattern
 
         protected override void OnDisable()
         {
+            base.OnDisable();
             
 #if UNITY_EDITOR
             UnityEditor.EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;


### PR DESCRIPTION
The example script below didn't work for me until the proposed changes were made.
The `ResetData()` function was not called.

```C#
using UnityEngine;

[CreateAssetMenu(fileName = "MainUpdater", menuName = "Scriptable Objects/MainUpdater")]
public class MainUpdater : ScriptableBehaviour
{
    [field: SerializeField]
    public float CurrentTime { get; private set; } = 0f;

    public override void OnUpdate()
    {
        CurrentTime += Time.deltaTime;
    }

    public override void ResetData()
    {
        Debug.Log("Reset Data");
        CurrentTime = 0;
    }
}
```
